### PR TITLE
added warnings when trying to get unknown config value or by env name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -91,9 +91,16 @@ func (c *Config) Get(internalName string) string {
 	// loop through all environment parameters and look for the internal name
 	// todo: enhance speed with an index if needed
 	for _, ep := range c.Environment {
+		if internalName == ep.EnvName {
+			log.Warnf("You're trying to get a config value by the environment variable name: %s", ep.EnvName)
+			log.Warnf("Please use the internal name instead: %s", ep.InternalName)
+			return ""
+		}
+
 		if ep.InternalName == internalName {
 			return ep.Value
 		}
 	}
+	log.Warnf("You're trying to get unknown config value: %s", internalName)
 	return ""
 }


### PR DESCRIPTION
@kskblr04 that you don't run into the issue of using then env name instead of the internal name 🙂 
@slot Should we crash fast with a fatal instead of just printing a warning?