### PR TITLE
Providing resources (simple MySQL implementation)

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,3 +37,7 @@
   # no master branch
   branch = "v2"
   name = "gopkg.in/yaml.v2"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/go-sql-driver/mysql"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # MIcroservice Support SYstem (MiSSy)
 
-[![Build Status](https://travis-ci.org/microdevs/missy.svg?branch=master)](https://travis-ci.org/microdevs/missy) [![Coverage Status](https://coveralls.io/repos/github/microdevs/missy/badge.svg?branch=master)](https://coveralls.io/github/microdevs/missy?branch=master)
+[![Slack Status](https://microdevs-slackin.herokuapp.com/badge.svg)](https://microdevs-slackin.herokuapp.com) [![Build Status](https://travis-ci.org/microdevs/missy.svg?branch=master)](https://travis-ci.org/microdevs/missy) [![Coverage Status](https://coveralls.io/repos/github/microdevs/missy/badge.svg?branch=master)](https://coveralls.io/github/microdevs/missy?branch=master)
+
 
 MISSY is a library for creating REST services that talk to each other. It provides the following functionality
 

--- a/config/config.go
+++ b/config/config.go
@@ -28,8 +28,6 @@ func GetInstance() *Config {
 		if parseErr != nil {
 			log.Fatalf("Cannot parse config file %s with error: \"%s\"", MissyConfigFile, parseErr)
 		}
-
-		config.ParseEnv()
 	})
 
 	return config
@@ -96,4 +94,11 @@ func (c *Config) Get(internalName string) string {
 		}
 	}
 	return ""
+}
+
+func (c *Config) AddEnv(params ...EnvParameter) *Config {
+	for _,p := range params {
+		c.Environment = append(c.Environment, p)
+	}
+	return c
 }

--- a/config/config.go
+++ b/config/config.go
@@ -105,8 +105,9 @@ func (c *Config) Get(internalName string) string {
 	return ""
 }
 
+// AddEnv allow it to add an env parameter from code
 func (c *Config) AddEnv(params ...EnvParameter) *Config {
-	for _,p := range params {
+	for _, p := range params {
 		c.Environment = append(c.Environment, p)
 	}
 	return c

--- a/config/model.go
+++ b/config/model.go
@@ -18,3 +18,12 @@ type EnvParameter struct {
 	Usage string`yaml:"usage"`
 	Value string `yaml:"value,omitempty"`
 }
+// tests if resource is configured in config. We assume that this resource is then available
+func (c *Config) ResourceAvailable(test string) bool {
+	for _,v := range c.Resources {
+		if v == test {
+			return true
+		}
+	}
+	return false
+}

--- a/config/model.go
+++ b/config/model.go
@@ -4,7 +4,7 @@ package config
 type Config struct {
 	Name        string         `yaml:"name"`
 	Environment []EnvParameter `yaml:"environment,flow,omitempty"`
-	Resources 	[]string `yaml:"resources,omitempty"`
+	Resources   []string       `yaml:"resources,omitempty"`
 }
 
 // EnvParameter defines how a config value is passed through an environment variable. This struct as members for
@@ -19,9 +19,10 @@ type EnvParameter struct {
 	Usage        string `yaml:"usage"`
 	Value        string `yaml:"value,omitempty"`
 }
-// tests if resource is configured in config. We assume that this resource is then available
+
+// ResourceAvailable tests if resource is configured in config. We assume that this resource is then available
 func (c *Config) ResourceAvailable(test string) bool {
-	for _,v := range c.Resources {
+	for _, v := range c.Resources {
 		if v == test {
 			return true
 		}

--- a/config/model.go
+++ b/config/model.go
@@ -4,6 +4,7 @@ package config
 type Config struct {
 	Name string `yaml:"name"`
 	Environment []EnvParameter `yaml:"environment,flow,omitempty"`
+	Resources []string `yaml:"resources,omitempty"`
 }
 // Defines how a config value is passed through an environment variable. This struct as members for
 // default values and usage description. It also can mark the variable non-mandatory. An external system

--- a/resource/mongodb.go
+++ b/resource/mongodb.go
@@ -1,22 +1,55 @@
 package resource
 
 import (
+	"github.com/microdevs/missy/config"
 	"gopkg.in/mgo.v2"
+	"log"
 )
 
-var mgoInstance *mgo.Database
+var mgoInstance *MgoDb
+
+const MgoResourceName = "mongodb"
+const MgoEnvDSN = MgoResourceName + ".dataSourceName"
 
 // Mysql is a type that holds the current active connection and its properties
-type Mgo struct {
-	Username string
-	Password string
-	Db       string
-	Host     string
-	Port     string
-	Session  *mgo.Session
+type MgoDb struct {
+	Dsn     string
+	Session *mgo.Session
 }
 
+func MgoSession() *mgo.Session {
+	if !config.GetInstance().ResourceAvailable(MgoResourceName) {
+		log.Panic("Resource MySQL is not configured. Please add a resource entry in .missy.yml")
+		return nil
+	}
 
-func MgoConnection() *mgo.Database {
+	once.Do(func() {
+		dsn := config.Get(MgoEnvDSN)
+		session, err := mgo.Dial(dsn)
 
+		if err != nil {
+			log.Fatal("Dialing into %s: %v", dsn, err)
+		}
+
+		log.Printf("Connected to DB %s", dsn)
+
+		// Setup adds the MongoDb parameters to the service config
+		mgoInstance = &MgoDb{Dsn: dsn, Session: session}
+	})
+
+	// Do not forget to close it.
+	return mgoInstance.Session.Clone()
 }
+
+func (r *MgoDb) Setup(c *config.Config) {
+	dsn := config.EnvParameter{
+		EnvName:      "MYSQL_DSN",
+		Mandatory:    true,
+		InternalName: MgoEnvDSN,
+		Usage:        MgoResourceName + " Data Service Name",
+		DefaultValue: "",
+	}
+	c.AddEnv(dsn)
+}
+
+// Leave the DB name empty so that we use the DB from the dialed url

--- a/resource/mongodb.go
+++ b/resource/mongodb.go
@@ -1,0 +1,22 @@
+package resource
+
+import (
+	"gopkg.in/mgo.v2"
+)
+
+var mgoInstance *mgo.Database
+
+// Mysql is a type that holds the current active connection and its properties
+type Mgo struct {
+	Username string
+	Password string
+	Db       string
+	Host     string
+	Port     string
+	Session  *mgo.Session
+}
+
+
+func MgoConnection() *mgo.Database {
+
+}

--- a/resource/mongodb.go
+++ b/resource/mongodb.go
@@ -38,7 +38,7 @@ func MgoSession() *mgo.Session {
 	})
 
 	// Do not forget to close it.
-	return mgoInstance.Session.Clone()
+	return mgoInstance.Session
 }
 
 func (r *MgoDb) Setup(c *config.Config) {

--- a/resource/mysql.go
+++ b/resource/mysql.go
@@ -1,0 +1,73 @@
+package resource
+
+import (
+	"database/sql"
+	"github.com/microdevs/missy/log"
+	"github.com/microdevs/missy/config"
+)
+
+type Mysql struct {
+	Username string
+	Password string
+	Db string
+	Host string
+	Port string
+	ActiveConnection *sql.DB
+}
+
+func (r *Mysql) Connection() (*sql.DB, error) {
+	if r.ActiveConnection == nil {
+		db, err := sql.Open("mysql", "hello")
+		if err != nil {
+			log.Errorf("Connection to ")
+			return nil, err
+		}
+		r.ActiveConnection = db
+	}
+
+	return r.ActiveConnection, nil
+}
+
+func (r *Mysql) Setup(c *config.Config) {
+	user := config.EnvParameter{
+		EnvName: "MYSQL_USER",
+		Mandatory: true,
+		InternalName: "mysql.user",
+		Usage: "MySQL User Name",
+		DefaultValue: "",
+	}
+
+	password := config.EnvParameter{
+		EnvName: "MYSQL_PASSWORD",
+		Mandatory: true,
+		InternalName: "mysql.password",
+		Usage: "MySQL Password",
+		DefaultValue: "",
+	}
+
+	host := config.EnvParameter{
+		EnvName: "MYSQL_HOST",
+		Mandatory: false,
+		InternalName: "mysql.host",
+		Usage: "MySQL Host",
+		DefaultValue: "localhost",
+	}
+
+	port := config.EnvParameter{
+		EnvName: "MYSQL_PORT",
+		Mandatory: false,
+		InternalName: "mysql.port",
+		Usage: "MySQL Host",
+		DefaultValue: "3306",
+	}
+
+	db := config.EnvParameter{
+		EnvName: "MYSQL_DB",
+		Mandatory: false,
+		InternalName: "mysql.db",
+		Usage: "MySQL Host",
+		DefaultValue: "mysql",
+	}
+
+	c.AddEnv(user, password, host, port, db)
+}

--- a/resource/mysql.go
+++ b/resource/mysql.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 )
 
+const MysqlResourceName = "mysql"
+
 var mysqlInstance *Mysql
 var once sync.Once
 
@@ -22,6 +24,12 @@ type Mysql struct {
 }
 
 func MysqlConnection() *sql.DB {
+
+	if !config.GetInstance().ResourceAvailable(MysqlResourceName) {
+		log.Panic("Resource MySQL is not configured. Please add a resource entry in .missy.yml")
+		return nil
+	}
+
 	once.Do(func() {
 		mysql := Mysql{
 			Username: config.Get("mysql.user"),

--- a/resource/mysql.go
+++ b/resource/mysql.go
@@ -2,18 +2,21 @@ package resource
 
 import (
 	"database/sql"
-	_ "github.com/go-sql-driver/mysql"
 	"fmt"
+	// blank import for mysql driver
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/microdevs/missy/config"
 	"github.com/microdevs/missy/log"
 	"sync"
 )
 
+// MysqlResourceName is the name of the resource type MySQL
 const MysqlResourceName = "mysql"
 
 var mysqlInstance *Mysql
 var once sync.Once
 
+// Mysql is a type that holds the current active connection and its properties
 type Mysql struct {
 	Username         string
 	Password         string
@@ -23,6 +26,7 @@ type Mysql struct {
 	ActiveConnection *sql.DB
 }
 
+// MysqlConnection returns the active connection of the Mysql type above
 func MysqlConnection() *sql.DB {
 
 	if !config.GetInstance().ResourceAvailable(MysqlResourceName) {
@@ -34,9 +38,9 @@ func MysqlConnection() *sql.DB {
 		mysql := Mysql{
 			Username: config.Get("mysql.user"),
 			Password: config.Get("mysql.password"),
-			Db: config.Get("mysql.db"),
-			Host: config.Get("mysql.host"),
-			Port: config.Get("mysql.port"),
+			Db:       config.Get("mysql.db"),
+			Host:     config.Get("mysql.host"),
+			Port:     config.Get("mysql.port"),
 		}
 		connection, err := mysql.Connect()
 		if err != nil {
@@ -48,6 +52,7 @@ func MysqlConnection() *sql.DB {
 	return mysqlInstance.ActiveConnection
 }
 
+// Connect to the MySQL server
 func (r *Mysql) Connect() (*sql.DB, error) {
 
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true", r.Username, r.Password, r.Host, r.Port, r.Db)
@@ -64,6 +69,7 @@ func (r *Mysql) Connect() (*sql.DB, error) {
 	return r.ActiveConnection, nil
 }
 
+// Setup adds the MySQL parameters to the service config
 func (r *Mysql) Setup(c *config.Config) {
 	user := config.EnvParameter{
 		EnvName:      "MYSQL_USER",

--- a/resource/mysql.go
+++ b/resource/mysql.go
@@ -4,6 +4,9 @@ import (
 	"database/sql"
 	"github.com/microdevs/missy/log"
 	"github.com/microdevs/missy/config"
+	"net/http"
+	"fmt"
+	"github.com/gorilla/context"
 )
 
 type Mysql struct {
@@ -16,8 +19,11 @@ type Mysql struct {
 }
 
 func (r *Mysql) Connection() (*sql.DB, error) {
+
+	dsn := fmt.Sprintf("mysql://%s:%s@%s:%s/%s",r.Username,r.Password,r.Host,r.Port,r.Db)
+
 	if r.ActiveConnection == nil {
-		db, err := sql.Open("mysql", "hello")
+		db, err := sql.Open("mysql", dsn)
 		if err != nil {
 			log.Errorf("Connection to ")
 			return nil, err
@@ -70,4 +76,16 @@ func (r *Mysql) Setup(c *config.Config) {
 	}
 
 	c.AddEnv(user, password, host, port, db)
+}
+
+func (r *Mysql) Initialize(req *http.Request) {
+	resource := Mysql{
+		Username: config.Get("mysql.user"),
+		Password: config.Get("mysql.password"),
+		Db: config.Get("mysql.db"),
+		Host: config.Get("mysql.host"),
+		Port: config.Get("mysql.port"),
+	}
+
+	context.Set(req, MysqlResourceKey, &resource)
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"github.com/go-playground/locales/mg"
 	"github.com/microdevs/missy/config"
 	"net/http"
 )
@@ -19,6 +20,9 @@ func Setup(c *config.Config) {
 		case MysqlResourceName:
 			my := Mysql{}
 			my.Setup(c)
+		case MgoResourceName:
+			mg := MgoDb{}
+			mg.Setup(c)
 		}
 	}
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -14,7 +14,7 @@ type Instance interface {
 func Setup(c *config.Config) {
 	for _, r := range c.Resources {
 		switch r {
-		case "mysql":
+		case MysqlResourceName:
 			my := Mysql{}
 			my.Setup(c)
 		}

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -1,7 +1,6 @@
 package resource
 
 import (
-	"github.com/go-playground/locales/mg"
 	"github.com/microdevs/missy/config"
 	"net/http"
 )

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 )
 
-const MysqlResourceKey int = 100
-
 type Instance interface {
 	Connection() (interface{}, error)
 	Setup(c *config.Config)
@@ -14,7 +12,7 @@ type Instance interface {
 }
 
 func Setup(c *config.Config) {
-	for _,r := range c.Resources{
+	for _, r := range c.Resources {
 		switch r {
 		case "mysql":
 			my := Mysql{}
@@ -22,15 +20,3 @@ func Setup(c *config.Config) {
 		}
 	}
 }
-
-func Initialize(req *http.Request) {
-	c := config.GetInstance()
-	for _,r := range c.Resources{
-		switch r {
-		case "mysql":
-			my := Mysql{}
-			my.Initialize(req)
-		}
-	}
-}
-

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 )
 
+// Instance interface
 type Instance interface {
 	Connection() (interface{}, error)
 	Setup(c *config.Config)
 	Initialize(r *http.Request)
 }
 
+// Setup calls Setup() functions on all registered resources
 func Setup(c *config.Config) {
 	for _, r := range c.Resources {
 		switch r {

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -2,11 +2,15 @@ package resource
 
 import (
 	"github.com/microdevs/missy/config"
+	"net/http"
 )
+
+const MysqlResourceKey int = 100
 
 type Instance interface {
 	Connection() (interface{}, error)
 	Setup(c *config.Config)
+	Initialize(r *http.Request)
 }
 
 func Setup(c *config.Config) {
@@ -18,3 +22,15 @@ func Setup(c *config.Config) {
 		}
 	}
 }
+
+func Initialize(req *http.Request) {
+	c := config.GetInstance()
+	for _,r := range c.Resources{
+		switch r {
+		case "mysql":
+			my := Mysql{}
+			my.Initialize(req)
+		}
+	}
+}
+

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -1,0 +1,20 @@
+package resource
+
+import (
+	"github.com/microdevs/missy/config"
+)
+
+type Instance interface {
+	Connection() (interface{}, error)
+	Setup(c *config.Config)
+}
+
+func Setup(c *config.Config) {
+	for _,r := range c.Resources{
+		switch r {
+		case "mysql":
+			my := Mysql{}
+			my.Setup(c)
+		}
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -17,6 +17,7 @@ import (
 	"os/signal"
 	"time"
 	gctx "github.com/gorilla/context"
+	"github.com/microdevs/missy/resource"
 )
 
 type key int
@@ -78,6 +79,8 @@ func New() *Service {
 	}
 
 	c := config.GetInstance()
+	resource.Setup(c)
+	c.ParseEnv()
 
 	return &Service{
 		name: c.Name,

--- a/service/service.go
+++ b/service/service.go
@@ -135,6 +135,7 @@ func (s *Service) HandleFunc(pattern string, handler func(*ResponseWriter, *http
 		// build context
 		gctx.Set(r, PrometheusInstance, s.Prometheus)
 		gctx.Set(r, RouterInstance, s.Router)
+		resource.Initialize(r)
 		// use our response writer
 		w := &ResponseWriter{originalResponseWriter, http.StatusOK}
 		// call custom handler

--- a/service/service.go
+++ b/service/service.go
@@ -23,7 +23,7 @@ import (
 type key int
 
 const PrometheusInstance key = 0
-const RouterInstance key = 1
+const RouterInstance key  = 1
 const RequestTimer key = 2
 
 type Service struct {
@@ -135,7 +135,6 @@ func (s *Service) HandleFunc(pattern string, handler func(*ResponseWriter, *http
 		// build context
 		gctx.Set(r, PrometheusInstance, s.Prometheus)
 		gctx.Set(r, RouterInstance, s.Router)
-		resource.Initialize(r)
 		// use our response writer
 		w := &ResponseWriter{originalResponseWriter, http.StatusOK}
 		// call custom handler


### PR DESCRIPTION
If a service needs a resource (db, cache, queue etc) which can be provided by a dedicated container running this service the developer can add the resource to `.missy.yml`

Example:
```yaml
name: demo
resources:
  - "mysql"
```

The ides is that missy-controller will spin up the needed resources, configure them and place a config in Kubernetes before starting the service. Meaning when the service comes up the dedicated resources are already there and can be used.

Looking at the API for the developer using resources is very simple. @levrik @gizioo @wojciech12 @pbsmacc  please critically check this first draft. I used a singleton pattern to hold the current MySQL session but it can be swopped easily during testing.

The code example looks as follows

```go
package main

import (
	"net/http"
	"time"
	"github.com/microdevs/missy/service"
	"github.com/microdevs/missy/resource"
	"github.com/microdevs/missy/log"
)


func main() {

	s := service.New()

	s.HandleFunc("/log", func(w *service.ResponseWriter, r *http.Request) {

		_, err := resource.MysqlConnection().Exec("INSERT into accesslog (accessTime, agent) values (NOW(),?)", r.UserAgent())
		if err!= nil {
			w.Error("DB query failed", http.StatusInternalServerError)
		}
		w.Write([]byte("OK wrote log"))
	}).Methods(http.MethodPost)

	s.Start()
}
```

Let me know what you think. In the meantime I will prepare the missy-controller to prove the resource spin up flow works. 

