### PR TITLE
Removed syscall package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"sync"
-	"syscall"
 )
 
 // MissyConfigFile holds the default config file name
@@ -59,7 +58,7 @@ func (c *Config) ParseEnv() {
 	var failedParameters []EnvParameter
 	// loop through registered parameters and try to find them in env
 	for k, parameter := range config.Environment {
-		envValue, found := syscall.Getenv(parameter.EnvName)
+		envValue, found := os.LookupEnv(parameter.EnvName)
 		// if mandatory but not found add them to error list
 		if found == false && parameter.Mandatory == true {
 			failedParameters = append(failedParameters, parameter)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	_ "syscall"
 	"testing"
 )
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -56,8 +55,8 @@ func TestNewService(t *testing.T) {
 func TestNewServiceWithDifferentHostPort(t *testing.T) {
 	testhost := "devil.hell"
 	testport := "666"
-	syscall.Setenv("LISTEN_HOST", testhost)
-	syscall.Setenv("LISTEN_PORT", testport)
+	os.Setenv("LISTEN_HOST", testhost)
+	os.Setenv("LISTEN_PORT", testport)
 
 	s := New()
 


### PR DESCRIPTION
It should not be used directly anymore. See https://golang.org/pkg/syscall