### PR TITLE
fixing double writing to response

### DIFF
--- a/data/marshaller.go
+++ b/data/marshaller.go
@@ -48,8 +48,6 @@ func MarshalResponse(w http.ResponseWriter, r *http.Request, subject interface{}
 		log.Errorf("Error marshalling to %s: %v", convertTo, err)
 	}
 
-	w.Write(resp)
-
 	return resp, err
 }
 


### PR DESCRIPTION
This is important fix. Now missy double write to the response writer. Once during data.MarshalResponse(...) and second time in Marshal function on the ResponseWriter. This fix removes redundant one from data.MarshalResponse(...) because it should just prepare the data not actually marshal it.