### PR TITLE
proposition of dead letter queue implementation:

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,8 +48,8 @@
   #version = "1.2.0"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/bouk/monkey"
+  version = "1.0.0"
 
 [[constraint]]
   branch = "master"

--- a/README.md
+++ b/README.md
@@ -122,7 +122,11 @@ err := reader.Read(func(msg Message) error{
 defer reader.Close()
 ```
 
-Writer with brokers hosts and topic
+#####Dead letter queue
+
+If you need to save messages that couldn't be processed, you have to use constructor NewReaderWithDLQ which takes name of DLQ topic as additional parameter.
+
+#####Writer with brokers hosts and topic
 
 ```go
 writer := messaging.NewWriter([]string{"localhost:9092"}, "topic")
@@ -131,3 +135,4 @@ err := writer.Write([]byte("key"), []byte("value"))
 // remember to close writer after use
 defer writer.Close()
 ```
+

--- a/messaging/reader.go
+++ b/messaging/reader.go
@@ -5,6 +5,10 @@ import (
 	"errors"
 	"io"
 
+	"strconv"
+	"time"
+
+	"github.com/microdevs/missy/config"
 	"github.com/microdevs/missy/log"
 	"github.com/segmentio/kafka-go"
 )
@@ -29,11 +33,14 @@ type BrokerReader interface {
 
 // missyReader used as a default missy Reader implementation
 type missyReader struct {
-	brokers      []string
-	groupID      string
-	topic        string
-	brokerReader BrokerReader
-	readFunc     *ReadMessageFunc
+	brokers         []string
+	groupID         string
+	topic           string
+	brokerReader    BrokerReader
+	readFunc        *ReadMessageFunc
+	dlqWriter       Writer
+	maxRetries      int
+	retriesInterval time.Duration
 }
 
 // readBroker us as a wrapper for kafka.Reader implementation to fulfill BrokerReader interface
@@ -94,7 +101,47 @@ func NewReader(brokers []string, groupID string, topic string) Reader {
 		MaxBytes:       10e6, // 10MB do we want it from config?
 	})
 
-	return &missyReader{brokers: brokers, groupID: groupID, topic: topic, brokerReader: &readBroker{kafkaReader}}
+	retries, intervalTime := fetchRetriesAndInterval()
+
+	log.Infof("Configured num of maxRetries: %v with interval %v", retries, intervalTime)
+
+	return &missyReader{brokers: brokers,
+		groupID:         groupID,
+		topic:           topic,
+		brokerReader:    &readBroker{kafkaReader},
+		maxRetries:      retries,
+		retriesInterval: intervalTime,
+	}
+}
+
+func NewReaderWithDLQ(brokers []string, groupID string, topic string, dlqTopic string) Reader {
+	kafkaReader := kafka.NewReader(kafka.ReaderConfig{
+		Brokers:        brokers,
+		GroupID:        groupID,
+		Topic:          topic,
+		CommitInterval: 0,    // 0 indicates that commits should be done synchronically
+		MinBytes:       10e3, // 10KB do we want it from config?
+		MaxBytes:       10e6, // 10MB do we want it from config?
+	})
+
+	retries, intervalTime := fetchRetriesAndInterval()
+	log.Infof("Configured num of maxRetries: %v with interval %v", retries, intervalTime)
+
+	if dlqTopic == "" {
+		dlqTopic = topic + ".dlq"
+		log.Debugf("Setting default dlq topic name because none was passed")
+	}
+
+	log.Infof("Configured %s as topic name for dead letter queue for topic %s", dlqTopic, topic)
+
+	return &missyReader{brokers: brokers,
+		groupID:         groupID,
+		topic:           topic,
+		brokerReader:    &readBroker{kafkaReader},
+		dlqWriter:       NewWriter(brokers, dlqTopic),
+		maxRetries:      retries,
+		retriesInterval: intervalTime,
+	}
 }
 
 // Read start reading goroutine that calls msgFunc on new message, you need to close it after use
@@ -118,23 +165,62 @@ func (mr *missyReader) Read(msgFunc ReadMessageFunc) error {
 			}
 
 			log.Infof("# messaging # new message: [topic] %v; [part] %v; [offset] %v; %s = %s\n", m.Topic, m.Partition, m.Offset, string(m.Key), string(m.Value))
-			if err := msgFunc(m); err != nil {
-				log.Errorf("# messaging # cannot commit a message: %v", err)
+			if err := mr.processMessage(msgFunc, m, 0); err != nil {
+				log.Errorf("# messaging # %v, sending message to dead letter queue", err)
+
+				if mr.dlqWriter != nil {
+					if err = mr.dlqWriter.Write(m.Key, m.Value); err != nil {
+						log.Errorf("Sending message to dead letter queue failed because: %v", err)
+					}
+				}
+				mr.commit(ctx, m)
 				continue
 			}
 
 			// commit message if no error
-			if err := mr.brokerReader.CommitMessages(ctx, m); err != nil {
-				// should we do something else to just logging not committed message?
-				log.Errorf("cannot commit message [%s] %v/%v: %s = %s; with error: %v", m.Topic, m.Partition, m.Offset, string(m.Key), string(m.Value), err)
-			}
+			mr.commit(ctx, m)
 		}
 	}()
 
+	return nil
+}
+func (mr *missyReader) commit(ctx context.Context, m Message) {
+	if err := mr.brokerReader.CommitMessages(ctx, m); err != nil {
+		// should we do something else to just logging not committed message?
+		log.Errorf("cannot commit message [%s] %v/%v: %s = %s; with error: %v", m.Topic, m.Partition, m.Offset, string(m.Key), string(m.Value), err)
+	}
+}
+
+//will try to process same message for configured number of times
+func (mr *missyReader) processMessage(msgFunc ReadMessageFunc, message Message, retryNumber int) error {
+
+	if retryNumber > mr.maxRetries {
+		return errors.New("reached maximum number of retries")
+	}
+	if err := msgFunc(message); err != nil {
+		log.Errorf("# messaging # retry number %v failed, trying again", retryNumber)
+		time.Sleep(mr.retriesInterval)
+		return mr.processMessage(msgFunc, message, retryNumber+1)
+	}
 	return nil
 }
 
 // Close used to close underlying connection with broker
 func (mr *missyReader) Close() error {
 	return mr.brokerReader.Close()
+}
+
+func fetchRetriesAndInterval() (int, time.Duration) {
+	retries, err := strconv.Atoi(config.Get("kafka.retries.max.number"))
+	if retries <= 0 || err != nil {
+		log.Debug("Setting retries number to 3, as kafka.retries.max.number was not set or wrong")
+		retries = 3
+	}
+	var intervalTime time.Duration
+	interval, err := strconv.Atoi(config.Get("kafka.retries.interval.ms"))
+	if interval <= 0 || err != nil {
+		log.Debug("Setting retries interval to 5000 ms, as kafka.retries.interval.ms was not set or wrong")
+		intervalTime = 5000 * time.Millisecond
+	}
+	return retries, intervalTime
 }


### PR DESCRIPTION
I've created this PR to open discussion, ignore the code for now.

So.. consumer groups + commiting offsets does not really work the way we thought. Imagine situation when we have 3 messages (m1, m2, m3) and a consumer from consumer group starts to consume them. Processing m1 went fine, processing m2 failed.. what happens next? Even though consumer did not commit offset for m2 it will proceed to m3 on next poll. It **will not read** not commited message again. BOOM, message is lost. It would be read again only if this consumer crash and other one would take its place in consumer group (kafka rebalance). 
If consuming/processing succeeds with m3 it will commit offset for m3 which effectively will also commit offset for m2.

I can't see 100% correct and convenient solution for this problem, but what we can do is add Dead Letter Queues (DLQ) concept to our kafka topics. This way we can at least trace and react manually if something is really bad with particular message. 

lets say - try 5 times to process message, if it fails then move it to DLQ and pray :) (We could also send some notification on email / slack in a future )

1.If consuming message returns error then retry configured number of times ( resend same message to same topic but with retryCounter incremented).
2. If all tries failed and counter reached configured limit  - send message to DLQ so we can later do something with it. Topic name convention is topicName+".dlq".