### PR TITLE
feat(url): url helpers for retrieving query params operators

### DIFF
--- a/url/query/operators.go
+++ b/url/query/operators.go
@@ -1,0 +1,17 @@
+package query
+
+// basic operators
+const (
+	// sorting
+	Default = ""     // default operator
+	Asc     = "asc"  // ascending order
+	Desc    = "desc" // descending order
+	In      = "in"   // in
+	NIn     = "nin"  // not in
+	Eq      = "eq"   // equal
+	NEq     = "neq"  // not equal
+	GT      = "gt"   // greater than
+	GTE     = "gte"  // greater than or equal
+	LT      = "lt"   // less than
+	LTE     = "lte"  // less than or equal
+)

--- a/url/query/params.go
+++ b/url/query/params.go
@@ -1,0 +1,54 @@
+package query
+
+import (
+	"net/url"
+	"strings"
+)
+
+// Operators for operator -> values
+// Empty operator means that no operator is found near the value.
+// In this case server decides the default one
+type Operators map[string][]string
+
+// Values for parameter -> Operators
+type Values map[string]Operators
+
+// Parse parses query parameters for proper Values
+// it can parse i.e. ?value=gt:10&name=in:name1,name22&date=lt:2018-04-01,gt:2018-01-01
+func Parse(queryParams url.Values) Values {
+	// prepare query map
+	queryMap := make(Values, len(queryParams))
+
+	// parse the map
+	for k := range queryParams {
+		queryValues := queryParams[k]
+		// prepare operator queryValues map
+		opValues := make(Operators)
+
+		for _, qv := range queryValues {
+			// check for queryValues
+			val := strings.Split(qv, ",") // value separator [ie. val1,val2,val3]
+
+			for _, v := range val {
+				// split with operator
+				op := strings.Split(v, ":") // operator separator [ie. asc:key1 or gt:10]
+				currOp := Default           // empty mean no operator
+				valueIndex := 0             // index of the actual query value, default to 0
+				// check for operator
+				if len(op) > 1 {
+					// there is an operator
+					valueIndex = 1 // value should be at index 1, because operators at 0
+					currOp = op[0]
+				}
+
+				// assign value to operator
+				opValues[currOp] = append(opValues[currOp], op[valueIndex])
+			}
+
+		}
+
+		queryMap[k] = opValues
+	}
+
+	return queryMap
+}

--- a/url/query/params_test.go
+++ b/url/query/params_test.go
@@ -1,0 +1,62 @@
+package query_test
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+
+	. "github.com/microdevs/missy/url/query"
+)
+
+var testParams = []struct {
+	in  string
+	out Values
+}{
+	{"http://localhost?value=gt:10", Values{"value": Operators{GT: []string{"10"}}}},
+	{"http://localhost?value=gt:10&value=lte:100", Values{"value": Operators{GT: []string{"10"}, LTE: []string{"100"}}}},
+	{"http://localhost?sort=asc:key1", Values{"sort": Operators{Asc: []string{"key1"}}}},
+	{"http://localhost?sort=desc:key1,key2,key3", Values{"sort": Operators{Desc: []string{"key1"}, Default: []string{"key2", "key3"}}}},
+	{"http://localhost?sort=desc:key1,key2,asc:key3", Values{"sort": Operators{Asc: []string{"key3"}, Desc: []string{"key1"}, Default: []string{"key2"}}}},
+	{"http://localhost?date=gt:2018-01-01&date=lte:2018-04-01", Values{"date": Operators{GT: []string{"2018-01-01"}, LTE: []string{"2018-04-01"}}}},
+	{"http://localhost?name=name&first_value=100&desc_value=inner", Values{"name": Operators{Default: []string{"name"}}, "first_value": Operators{Default: []string{"100"}}, "desc_value": Operators{Default: []string{"inner"}}}},
+}
+
+func TestParse(t *testing.T) {
+	for _, tt := range testParams {
+		t.Run(tt.in, func(t *testing.T) {
+
+			parsedURL, err := url.Parse(tt.in)
+			if err != nil {
+				t.Errorf("cannot parse raw url: %v", err)
+			}
+
+			queryParams, err := url.ParseQuery(parsedURL.RawQuery)
+			if err != nil {
+				t.Errorf("cannot parse query: %v", err)
+			}
+
+			queryValues := Parse(queryParams)
+			if len(tt.out) != len(queryValues) {
+				t.Errorf("invalid query paramterers Parsing len, expected: %v = %v", len(tt.out), len(queryValues))
+			}
+
+			for paramKey, values := range queryValues {
+				if _, ok := tt.out[paramKey]; !ok {
+					t.Errorf("Values paramKey key not exist: %s", paramKey)
+				}
+
+				expectedQueryValues := tt.out[paramKey]
+
+				for op, v := range values {
+					if _, ok := expectedQueryValues[op]; !ok {
+						t.Errorf("Values operator not exist: %s", op)
+					}
+
+					if !reflect.DeepEqual(expectedQueryValues[op], v) {
+						t.Errorf("Values values not parsed correctly: expected len %v, got len %v", len(expectedQueryValues[op]), len(v))
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is to introduce url helpers for retrieving query params values with operators for advanced filtering and sorting for REST API.

For advanced query parameters with special operators:
in, nin, neq, gt, gte, lt, lte (in, not in, not equal, greater then, greater then or equal, less then, less the or equal), for sort we can use asc and desc operators:
- http://localhost?foo=in:a,b,c - means foo is in the list of a,b,c
- http://localhost?price=gt:10 - means price is greater then 10
- http://localhost?date=lte:2018-04-11 - date is less or equal then 2018-04-11
- http://localhost?sort=asc:key1&name=in:n1,n2,n3&value=gt:10,lte:100 - sort asc by key1, name in (n1,n2,n3) and 100 >= value > 10.
