### PR TITLE
refactor(service): Change default host to 0.0.0.0

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -68,7 +68,7 @@ type Service struct {
 }
 
 var listenPort = "8080"
-var listenHost = "localhost"
+var listenHost = "0.0.0.0"
 var controllerAddr string
 
 // FlagMissyControllerAddressDefault is a default for the missy-controller url used in the during service initialisation when given the init flag


### PR DESCRIPTION
Most frameworks that I've used listened on 0.0.0.0 by default.
With MiSSy I often ended up with wondering why my service isn't accessible.
That it's running on localhost is easy to miss in the logs (at least for me).