### PR TITLE
feat(messaging): adding hash func to message struct

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,8 +48,8 @@
   #version = "1.2.0"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/bouk/monkey"
+  version = "1.0.0"
 
 [[constraint]]
   branch = "master"

--- a/messaging/message.go
+++ b/messaging/message.go
@@ -1,6 +1,11 @@
 package messaging
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/gob"
+	"encoding/hex"
+	"hash"
 	"time"
 )
 
@@ -11,4 +16,37 @@ type Message struct {
 	Time      time.Time
 	Partition int
 	Offset    int64
+}
+
+// Hash returns bytes array of a hash of a Message using provided hash mechanism
+func (m Message) Hash(hash hash.Hash) ([]byte, error) {
+	var binBuffer bytes.Buffer
+	enc := gob.NewEncoder(&binBuffer)
+
+	if err := enc.Encode(m); err != nil {
+		return nil, err
+	}
+
+	return hash.Sum(binBuffer.Bytes()), nil
+}
+
+// HashString returns string representation of a hash of a Message using provided hash mechanism
+func (m Message) HashString(hash hash.Hash) (string, error) {
+	hashBytes, err := m.Hash(hash)
+	if err != nil {
+		return "", err
+	}
+
+	// return hash encoded to string
+	return hex.EncodeToString(hashBytes), nil
+}
+
+// Hash returns bytes array of a hash of a Message using Sha256 hash mechanism
+func (m Message) Sha256() ([]byte, error) {
+	return m.Hash(sha256.New())
+}
+
+// HashString returns string representation of a hash of a Message Sha256 hash mechanism
+func (m Message) Sha256String() (string, error) {
+	return m.HashString(sha256.New())
 }

--- a/messaging/message_test.go
+++ b/messaging/message_test.go
@@ -1,0 +1,72 @@
+package messaging_test
+
+import (
+	"crypto/sha1"
+	"testing"
+	"time"
+
+	. "github.com/microdevs/missy/messaging"
+)
+
+func TestMessage_Hash(t *testing.T) {
+	message := Message{
+		Topic:     "topicName",
+		Key:       []byte("key"),
+		Value:     []byte("value"),
+		Time:      time.Now(),
+		Partition: 0,
+		Offset:    12,
+	}
+
+	hashBytes, err := message.Hash(sha1.New())
+
+	if err != nil {
+		t.Errorf("error during message hashing!: %v", err)
+	}
+
+	if len(hashBytes) == 0 {
+		t.Error("hash bytes len is 0!")
+	}
+}
+
+func TestMessage_HashString(t *testing.T) {
+	message := Message{
+		Topic:     "topicName",
+		Key:       []byte("key"),
+		Value:     []byte("value"),
+		Time:      time.Now(),
+		Partition: 0,
+		Offset:    12,
+	}
+
+	hashString, err := message.HashString(sha1.New())
+
+	if err != nil {
+		t.Errorf("error during message hashing!: %v", err)
+	}
+
+	if len(hashString) == 0 {
+		t.Error("hash string len is 0!")
+	}
+}
+
+func TestMessage_Sha256String(t *testing.T) {
+	message := Message{
+		Topic:     "topicName",
+		Key:       []byte("key"),
+		Value:     []byte("value"),
+		Time:      time.Now(),
+		Partition: 0,
+		Offset:    12,
+	}
+
+	hashString, err := message.Sha256String()
+
+	if err != nil {
+		t.Errorf("error during message hashing!: %v", err)
+	}
+
+	if len(hashString) == 0 {
+		t.Error("hash string len is 0!")
+	}
+}


### PR DESCRIPTION
This PR adds `Hash` function to message. This will be convenient for underlying services to create a fingerprint of a message for further usage, i.e. to save this and checks if this message was consumed by a service.

This will help services to implement idempotent behaviour.
