### PR TITLE
fix(tokens): fixing helper for tokens and adding TokenIsValid func

### DIFF
--- a/service/helpers.go
+++ b/service/helpers.go
@@ -15,14 +15,18 @@ func Vars(r *http.Request) map[string]string {
 	return mux.Vars(r)
 }
 
-// Token returns the validated auth token from the request context
-func Token(r *http.Request) *jwt.Token {
-	return context.Get(r, "token").(*jwt.Token)
+// token returns the validated auth token from the request context
+func token(r *http.Request) *jwt.Token {
+	t := context.Get(r, "token")
+	if t == (*jwt.Token)(nil) {
+		return nil
+	}
+	return t.(*jwt.Token)
 }
 
 // TokenHasAccess checks if a valid access token contains a given policy in a context
 func TokenHasAccess(r *http.Request, context string, policy string) bool {
-	token := Token(r)
+	token := token(r)
 	// return false if there is no token
 	if token == nil {
 		return false
@@ -63,4 +67,15 @@ func TokenHasAccess(r *http.Request, context string, policy string) bool {
 	}
 	// if the requested policy was not found in the context, the function returns false
 	return false
+}
+
+// TokenIsValid checks if request has a valid token
+func TokenIsValid(r *http.Request) bool {
+	token := token(r)
+	// return false if there is no token
+	if token == nil {
+		return false
+	}
+
+	return token.Valid
 }

--- a/service/helpers_test.go
+++ b/service/helpers_test.go
@@ -48,3 +48,24 @@ func TestTokenHasAccess(t *testing.T) {
 		}
 	}
 }
+
+var tokenIsValidCases = []struct {
+	token  *jwt.Token
+	result bool
+}{
+	{&jwt.Token{Valid: false}, false},
+	{&jwt.Token{Valid: true}, true},
+	{&jwt.Token{}, false},
+	{nil, false},
+}
+
+func TestTokenIsValid(t *testing.T) {
+	for _, test := range tokenIsValidCases {
+		r := httptest.NewRequest(http.MethodGet, "/foo", http.NoBody)
+		context.Set(r, "token", test.token)
+		result := TokenIsValid(r)
+		if result != test.result {
+			t.Errorf("Result should be %t but was %t", test.result, result)
+		}
+	}
+}


### PR DESCRIPTION
- This PR fixing a token helpers func (nil as token in context was not handled)
- token func was change to not be exported. It's uses the `jwt.Token` explicit type. This should be a missy implementation details and not be exported. If we want to have a `token` type in missy, it should be a missy `interface` instead.
- new func for fast token validation added `TokenIsValid`. This validates token (i.e. if it's not expired already etc).