### PR TITLE
fix(service): proper handling of server closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ func JsonHandler(w http.ResponseWriter, r *http.Request) {
 curl "http://localhost:8088/hello/microdevs"
 ```
 
-Get Prometheus Metrics:
+Get Prometheus Metrics (all metrics are exposed on 8090 as default). To change this please set `METRICS_LISTEN_PORT` env. var.:
 ```
-curl http://localhost:8088/metrics
+curl http://localhost:8090/metrics
 ```
 
 ### Get Info:
 ```
-http://localhost:8088/info
+http://localhost:8090/info
 ```
 
 Response:
@@ -95,7 +95,7 @@ Uptime 14.504883092s
 ```
 ### Get Health:
 ```
-http://localhost:8088/health
+http://localhost:8090/health
 ```
 
 Response:

--- a/service/service.go
+++ b/service/service.go
@@ -180,7 +180,13 @@ func (s *Service) Start() {
 		for {
 			select {
 			case err := <-errChan:
-				log.Fatalf("server shut down due to %v", err)
+				logFunc := log.Fatalf
+				// if server is closed, it's not a fatal but info
+				// it means that there was a call to Shutdown or Close
+				if err == http.ErrServerClosed {
+					logFunc = log.Infof
+				}
+				logFunc("server shut down due to %v", err)
 			}
 		}
 	}()


### PR DESCRIPTION
A fix for proper handling of server closing. We don't want to make a fatal there. It just means that server is closing due to shutdown or close call.

Beside that I've update readme about metrics port now.