### PR TITLE
fix(messaging): Update monkey's import path

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,20 +2,20 @@
 
 
 [[projects]]
+  digest = "1:a6ee710e45210bafe11f2f28963571be2ac8809f9a7b675a6d2c02302a1ce1a9"
+  name = "bou.ke/monkey"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5df1f207ff77e025801505ae4d903133a0b4353f"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
   pruneopts = ""
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
-
-[[projects]]
-  digest = "1:a6ee710e45210bafe11f2f28963571be2ac8809f9a7b675a6d2c02302a1ce1a9"
-  name = "github.com/bouk/monkey"
-  packages = ["."]
-  pruneopts = ""
-  revision = "5df1f207ff77e025801505ae4d903133a0b4353f"
-  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -158,7 +158,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/bouk/monkey",
+    "bou.ke/monkey",
     "github.com/dgrijalva/jwt-go",
     "github.com/golang/mock/gomock",
     "github.com/gorilla/mux",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,7 +43,7 @@
   #version = "1.2.0"
 
 [[constraint]]
-  name = "github.com/bouk/monkey"
+  name = "bou.ke/monkey"
   version = "1.0.0"
 
 [[constraint]]

--- a/messaging/reader_test.go
+++ b/messaging/reader_test.go
@@ -9,7 +9,7 @@ import (
 
 	"reflect"
 
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	"github.com/segmentio/kafka-go"

--- a/messaging/writer_test.go
+++ b/messaging/writer_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	tm "time"
 
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	"github.com/segmentio/kafka-go"


### PR DESCRIPTION
Monkey's go.mod file defines the module's path as "bou.ke/monkey" and
that's how it needs to be used, otherwise `go mod` complains in packages
that use missy as a dependency.